### PR TITLE
Fix incorrect links and remove schema endpoint

### DIFF
--- a/endpoints-parameters.md
+++ b/endpoints-parameters.md
@@ -5,8 +5,6 @@ title:  "Endpoints and Parameters"
 
 Using the available endpoints and their parameters, you can construct queries to get data back from the API. 
 
-See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.rockarch.org/schema) to see how our API is structured and understand the data.
-
 ## Endpoints
 
 **Agents**: People, organizations or families.  
@@ -30,7 +28,6 @@ See the full OpenAPI schema at [https://api.rockarch.org/schema](https://api.roc
 |/terms/{id}|Returns data about an individual term.|
 |/search|Performs search queries across agents, collections, objects and terms.|
 |/search/{id}|Performs search queries across a specific agent, collection, object or term.
-|/schema/|Returns the OpenAPI schema for the RAC API.|
 
 ## Parameters
 Use our [browsable API](https://api.rockarch.org) to see which parameters are available for which endpoints. For example, [https://api.rockarch.org/collections](https://api.rockarch.org/collections) lists the filter and sort fields, or parameters, that are available for that endpoint at the top of the webpage.

--- a/use-api.md
+++ b/use-api.md
@@ -12,7 +12,7 @@ Get started with your favorite API tool or script. We do not require an API key.
 - We provide an [API client](https://pypi.org/project/rac-api-client/) to simplify requests if you are writing Python scripts.
 
 ## Quick start 
-The best way to learn what is available via the API is to start making API requests and exploring what comes back, whether in the [browsable API](https://api.rockarch.org) with URLs or using another interface. Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo/endpoints-parameters) section of this document.
+The best way to learn what is available via the API is to start making API requests and exploring what comes back, whether in the [browsable API](https://api.rockarch.org) with URLs or using another interface. Data is accessed through GET requests using API endpoints. For a list of available endpoints, see the [endpoints and parameters](/argo-docs/endpoints-parameters) section of this document.
 
 This section includes some basic examples to show you how to construct queries and start exploring.
 
@@ -51,7 +51,7 @@ Use the `/search` endpoint to return the number of search matches for the query 
 https://api.rockarch.org/search?&query=agriculture&category=collection&genre=photographs&start_date__gte=1940&end_date__lte=1950
 ```
 
-**Note**: As documented in the [parameters section](/argo/endpoints-parameters#parameters), appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates.
+**Note**: As documented in the [parameters section](/argo-docs/endpoints-parameters#parameters), appending `__gte` and `__lte` to the date parameters function as `greater than or equal to` and `less than or equal to`, allowing us to include any start and end dates in this decade instead of limiting ourselves to specific start and end dates.
 
 ### Example 5: Minimap
 Use the `/minimap` endpoint to return collections and objects with search hits for the query term "agriculture" within the Ford Foundation records collection:


### PR DESCRIPTION
Use correct internal links, and remove `/schema` endpoint that is no longer supported in argo (at api.rockarch.org)